### PR TITLE
fix(capmonster): fix errorId check and log for CapMonster

### DIFF
--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -1144,9 +1144,9 @@ class ServiceCrawler(Worker):  # pylint:disable=too-many-instance-attributes
                 )
                 return None
             resp_data = response.json()
-            if resp_data["error_id"] != 0:
+            if "errorId" in resp_data and resp_data["errorId"] != 0:
                 self.mylog(
-                    f"capmonster error {resp_data['error_id']}:"
+                    f"capmonster error {resp_data['errorId']}:"
                     f"{resp_data['errorDescription']}",
                     st="EE",
                 )
@@ -1165,7 +1165,7 @@ class ServiceCrawler(Worker):  # pylint:disable=too-many-instance-attributes
             while max_loops > 0:
                 max_loops -= 1
                 self.mylog(
-                    "Sleeping for 10 seconds to wait for 2Captcha", st="~~"
+                    "Sleeping for 10 seconds to wait for CapMonster", st="~~"
                 )
                 time.sleep(10)
                 response = requests.post(
@@ -1184,9 +1184,9 @@ class ServiceCrawler(Worker):  # pylint:disable=too-many-instance-attributes
                     )
                     # Try again - we've successfully requested a task
                     continue
-                if resp_data["error_id"] != 0:
+                if "errorId" in resp_data and resp_data["errorId"] != 0:
                     self.mylog(
-                        f"capmonster error {resp_data['error_id']}:"
+                        f"capmonster error {resp_data['errorId']}:"
                         f"{resp_data['errorDescription']}",
                         st="EE",
                     )


### PR DESCRIPTION
I had an issue running meters to ha with CapMonster: it seems they changed the format for their API for the error code, from `error_id` to `errorId`. Changing it solves the issue (KeyError) I had.
See API reference: https://zennolab.atlassian.net/wiki/spaces/APIS/pages/393308/createTask+captcha+task+creating#Response-structure

Also adjusted a log message to mention CapMonster instead of 2Captcha.

Thanks a lot for the huge work on this :)

Let me know if you need anything more for this PR