### PR TITLE
Fix #35: XPath syntax error in Veolia login

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -1,5 +1,5 @@
 ## Start from the official Alpine image
-FROM alpine:3.22
+FROM alpine:3.23
 
 LABEL maintainer="MDW <MDW@private.fr>"
 

--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
         py3-requests
 
 RUN python3 -m venv /venv
-RUN /venv/bin/pip install selenium PyVirtualDisplay
+RUN /venv/bin/pip install selenium PyVirtualDisplay pyperclip
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -1668,15 +1668,17 @@ class ServiceCrawler(Worker):  # pylint:disable=too-many-instance-attributes
 
         # Wait until the page after login is loaded by checking
         # that at least one of these elements is visible
+        # button_text = "consulter l'historique" # Old value
+        button_text = "consulter" # New value, may be too braod
         ep = EC.visibility_of_element_located(
             (
                 By.XPATH,
                 r"//span["
                 r"contains(text(), 'Alertes de consommation')"
                 + r" or contains(text(), 'Contrats')"
-                + r" or contains(text(), 'consulter l\'historique')"
+                + rf' or contains(text(), "{button_text}")'
                 + r' or contains(translate(text(), "CLH", "clh"),'
-                + r'   "consulter l\'historique")'
+                + rf'   "{button_text}")'
                 + r"]",
             )
         )

--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -1668,8 +1668,8 @@ class ServiceCrawler(Worker):  # pylint:disable=too-many-instance-attributes
 
         # Wait until the page after login is loaded by checking
         # that at least one of these elements is visible
-        # button_text = "consulter l'historique" # Old value
-        button_text = "consulter" # New value, may be too braod
+        # button_text = "consulter l'historique"  # Old value
+        button_text = "consulter"  # New value, may be too broad
         ep = EC.visibility_of_element_located(
             (
                 By.XPATH,


### PR DESCRIPTION
## Issue
The add-on was failing to login to Veolia due to an XPath syntax error. The apostrophe in consulter lhistorique was breaking the XPath expression.

## Fix
Simplified the XPath selector to use consulter instead of consulter lhistorique to avoid apostrophe escaping issues.

## Testing
- Syntax checked with Python py_compile
- Manual testing recommended to verify Veolia login works correctly