### PR TITLE
Fix #38: Total counter logic in Veolia historical data

### DIFF
--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -2624,10 +2624,14 @@ class Injector(Worker):
             for row in rows:
                 method = row[3]  # "Mesuré" or "Estimé"
                 if method in ("E", "Estimé"):
-                    # Ignore estimated index (we use the last total)
-                    meter_total = last_total + int(row[2])
-                else:
-                    meter_total = int(row[1]) + int(row[2])
+                    # Skip estimated data as suggested in issue #38
+                    # Estimated values will be available later as measured values
+                    self.mylog(f"    Skipping estimated data: {row[0]}")
+                    continue
+                
+                # For "Mesuré" rows, row[1] already contains the total counter value
+                # which includes all previous consumption. We don't need to add row[2].
+                meter_total = int(row[1])
 
                 date_obj = dt.datetime.strptime(row[0], date_format)
 


### PR DESCRIPTION
## Issue
The total counter calculation was incorrect in parse_veolia_historical_data:
- For estimated rows, it was using last_total + row[2] but last_total started at 0
- For measured rows, it was using row[1] + row[2], but row[1] already contains the total

## Fix
- Skip estimated (Estime) rows as they will be available later as measured values
- For measured (Mesure) rows, use row[1] directly as the total (which already includes all previous consumption)

## Testing
- Syntax checked with Python py_compile
- Manual testing recommended to verify historical data is calculated correctly