### PR TITLE
Fix #37: Separate Veolia historical data into total and period_total sensors

### DIFF
--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -3086,8 +3086,12 @@ class HomeAssistantInjector(Injector):
                 )
 
     def update_veolia_historical_data(self, stats_array):
-        # Prepare the statistics that need to be sent
-        data = {
+        # Prepare the statistics that need to be sent for _total sensor
+        total_stats = [
+            {"start": stat["start"], "state": stat["sum"]}
+            for stat in stats_array
+        ]
+        data_total = {
             "has_mean": False,
             "has_sum": True,
             "statistic_id": (
@@ -3096,10 +3100,36 @@ class HomeAssistantInjector(Injector):
             ),
             "unit_of_measurement": "L",
             "source": "recorder",
-            "stats": stats_array,
+            "stats": total_stats,
         }
-        self.mylog("Publish all the historical data in the statistics")
-        self.open_url(HA_API_STATISTICS, data)
+        self.mylog("Publish total historical data in the statistics")
+        self.open_url(HA_API_STATISTICS, data_total)
+        self.mylog(st="OK")
+
+        # Prepare the statistics that need to be sent for _period_total sensor
+        period_stats = [
+            {
+                "start": stat["start"],
+                "state": stat["state"],
+                "mean": stat["state"],
+                "min": stat["state"],
+                "max": stat["state"]
+            }
+            for stat in stats_array
+        ]
+        data_period = {
+            "has_mean": True,
+            "has_sum": False,
+            "statistic_id": (
+                "sensor.veolia_%s_period_total"
+                % self.configuration[PARAM_VEOLIA_CONTRACT]
+            ),
+            "unit_of_measurement": "L",
+            "source": "recorder",
+            "stats": period_stats,
+        }
+        self.mylog("Publish period historical data in the statistics")
+        self.open_url(HA_API_STATISTICS, data_period)
         self.mylog(st="OK")
 
     def update_veolia_service_eau_veolia_fr_device(self, stats_array):


### PR DESCRIPTION
## Issue
Veolia historical data was being sent only to the _total sensor, but should be separated into:
- sensor.veolia_{contract}_total for cumulative total values
- sensor.veolia_{contract}_period_total for daily consumption values

## Fix
Modified update_veolia_historical_data to send two separate statistic imports:
- Total stats with has_sum: true for cumulative values
- Period stats with has_mean: true for daily consumption

## Testing
- Syntax checked with Python py_compile
- Manual testing recommended to verify historical data is properly separated