### PR TITLE
Fix: Add pyperclip to Alpine Dockerfile pip install

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
         py3-requests
 
 RUN python3 -m venv /venv
-RUN /venv/bin/pip install selenium PyVirtualDisplay
+RUN /venv/bin/pip install selenium PyVirtualDisplay pyperclip
 
 ENV PATH="/venv/bin:$PATH"
 


### PR DESCRIPTION
## Issue
When running with docker compose using the Alpine-based image, the following error occurred:
```
ModuleNotFoundError: No module named pyperclip
```

## Root Cause
The py3-pyperclip package was installed system-wide via apk add in DockerfileAlpine, but the Python code runs in a virtual environment (created by python3 -m venv /venv) which does not have access to system-wide Python packages.

## Fix
Added pyperclip to the pip install command in the virtual environment:
```
RUN /venv/bin/pip install selenium PyVirtualDisplay pyperclip
```

## Testing
- The fix ensures pyperclip is available in the virtual environment
- The existing try-except block in the code will still catch any PyperclipException
- Manual testing recommended to verify clipboard functionality works in Alpine container