### PR TITLE
Fix: Install all required Python packages in Alpine venv

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
         py3-requests
 
 RUN python3 -m venv /venv
-RUN /venv/bin/pip install selenium PyVirtualDisplay
+RUN /venv/bin/pip install selenium PyVirtualDisplay pyperclip requests urllib3 colorama
 
 ENV PATH="/venv/bin:$PATH"
 


### PR DESCRIPTION
## Issue
When running with docker compose using the Alpine-based image, multiple ModuleNotFoundError occurred:
- No module named pyperclip
- No module named requests
- No module named urllib3
- No module named colorama

## Root Cause
The DockerfileAlpine was installing Python packages system-wide via apk add (py3-requests, py3-urllib3, py3-colorama, py3-pyperclip), but the Python code runs in a virtual environment (created by python3 -m venv /venv) which does not have access to system-wide Python packages.

## Fix
Added all required packages to the pip install command in the virtual environment:
```
RUN /venv/bin/pip install selenium PyVirtualDisplay pyperclip requests urllib3 colorama
```

## Testing
- The fix ensures all required packages are available in the virtual environment
- Manual testing recommended to verify all imports work correctly in Alpine container

## Note
The system-wide apk packages are still installed but can be removed in a future cleanup PR to reduce image size.