### PR TITLE
Fix: Use --system-site-packages for Alpine venv

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
         py3-urllib3 \
         py3-requests
 
-RUN python3 -m venv /venv
+RUN python3 -m venv --system-site-packages /venv
 RUN /venv/bin/pip install selenium PyVirtualDisplay
 
 ENV PATH="/venv/bin:$PATH"


### PR DESCRIPTION
## Issue
When running with docker compose using the Alpine-based image, ModuleNotFoundError occurred for packages like pyperclip, requests, urllib3, colorama because they were installed system-wide via apk add but not accessible in the virtual environment.

## Solution
Use the --system-site-packages flag when creating the virtual environment to allow it to access system-wide Python packages. This is more efficient than reinstalling all packages via pip.

## Changes
Changed:
```
RUN python3 -m venv /venv
```
To:
```
RUN python3 -m venv --system-site-packages /venv
```

## Benefits
- More efficient: No need to reinstall packages already available system-wide
- Faster build time
- Smaller image size (no duplicate packages)
- The venv now has access to all py3-* packages installed via apk add:
  - py3-requests
  - py3-urllib3
  - py3-colorama
  - py3-pyperclip
  - py3-paho-mqtt
  - And all others

## Testing
- Syntax checked with Dockerfile linting
- Manual testing recommended to verify all imports work correctly in Alpine container