### PR TITLE
Fix: Change --chrome-version argument type from int to str

### DIFF
--- a/apps/meters_to_ha/meters_to_ha.py
+++ b/apps/meters_to_ha/meters_to_ha.py
@@ -4010,7 +4010,7 @@ def doWork():
         "'This version of ChromeDriver only supports Chrome version ...'",
         required=False,
         nargs=1,
-        type=int,
+        type=str,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Issue
When passing a Chrome version string containing a + character (e.g., 123.0.6312.105+), the following error occurred:
```
meters_to_ha.py: error: argument --chrome-version: invalid int value: + 
```

## Root Cause
The --chrome-version argument was defined with type=int, which cannot parse version strings containing non-numeric characters like +.

## Fix
Changed the argument type from int to str to accept Chrome version strings as-is.

## Details
- Chrome version strings are typically in format MAJOR.MINOR.BUILD.PATCH
- They may contain non-numeric characters like + (e.g., 123.0.6312.105+)
- The version string is passed to uc.Chrome(version_main=...) which accepts strings

## Testing
- Syntax checked with Python py_compile
- Manual testing recommended to verify --chrome-version argument works with version strings containing +